### PR TITLE
Fixed support for dual-monitor arrangements

### DIFF
--- a/chronolapse.py
+++ b/chronolapse.py
@@ -607,7 +607,7 @@ class ChronoFrame(chronoFrame):
 
             try:
                 # use two monitors if checked and available
-                if (self.getConfig('screenshotdualmonitor')
+                if (self.getConfig('screenshot_dual_monitor')
                     and wx.Display_GetCount() > 0):
                     second = wx.Display(1)
                     x2, y2, width2, height2 = second.GetGeometry()


### PR DESCRIPTION
The config flag that was checked prior to actual image capture was different than the rest used to enable the config option. This simply changes the config option to match, the results have been tested as properly fixing dual monitor capture.